### PR TITLE
fix: adopt forward-compatible approach to `builder:watch`

### DIFF
--- a/packages/server-block-nuxt/src/module.ts
+++ b/packages/server-block-nuxt/src/module.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/prefer-ts-expect-error */
 import { existsSync, promises as fsp } from "node:fs"
-import { resolve as pathResolve } from "node:path"
+import { relative, resolve as pathResolve } from "node:path"
 import { addPlugin, createResolver, defineNuxtModule, useNitro } from "@nuxt/kit"
 import ExtractSFCBlock from "@hebilicious/extract-sfc-block"
 
@@ -95,6 +95,7 @@ export default defineNuxtModule({
 
     // 4.Watch directories, split handlers and add them to Nitro/Nuxt
     nuxt.hook("builder:watch", async (event, path) => {
+      path = relative(nuxt.options.srcDir, pathResolve(nuxt.options.srcDir, path))
       try {
         await addHandlers(path, event)
       }


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

We are planning to move to [emitting absolute paths in `builder:watch` in Nuxt v4](https://github.com/nuxt/nuxt/issues/25339). You can see a little more about the history in the PR linked in that issue.

This PR is an attempt to use a forward/backward compatible approach, namely resolving the path to ensure it's absolute, then making it relative so your existing code will continue to work.

This should be safe to merge as is, but do let me know if you have any concerns about this approach.



### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
